### PR TITLE
Add emission line luminosity calculations to galaxy catalog generation

### DIFF
--- a/src/covariance_mocks/emission_lines.py
+++ b/src/covariance_mocks/emission_lines.py
@@ -1,0 +1,60 @@
+"""
+Emission Line Module
+
+Calculates emission line luminosities from star formation rates using rgrspit_diffsky.
+"""
+
+import numpy as np
+
+
+def add_emission_lines(galcat):
+    """
+    Add emission line luminosities to galaxy catalog.
+    
+    Calculates OII and H-alpha line luminosities from the star formation rate
+    at the observation time using the star formation history table.
+    
+    Parameters
+    ----------
+    galcat : dict
+        Galaxy catalog from rgrspit_diffsky containing:
+        - 'sfh_table' : star formation history table (N_galaxies, n_time_bins) 
+        - 't_table' : time array corresponding to sfh_table bins
+        - 't_obs' : observation time
+        
+    Returns
+    -------
+    dict
+        Modified galaxy catalog with added keys:
+        - 'l_oii' : OII line luminosity (N_galaxies,)
+        - 'l_halpha' : H-alpha line luminosity (N_galaxies,)
+        
+    Notes
+    -----
+    - Extracts SFR from sfh_table at the time bin closest to t_obs
+    - Uses rgrspit_diffsky emission line functions for conversions
+    - SFR units should be M_sun/yr for proper luminosity calculations
+    """
+    from rgrspit_diffsky.emission_lines.oii import sfr_to_OII3727_K98
+    from rgrspit_diffsky.emission_lines.halpha import sfr_to_Halpha_KTC94
+    
+    # Extract arrays from galaxy catalog
+    sfh_table = np.array(galcat['sfh_table'])  # (N_galaxies, n_time_bins)
+    t_table = np.array(galcat['t_table'])      # (n_time_bins,)
+    t_obs = float(galcat['t_obs'])             # scalar
+    
+    # Find the time bin closest to t_obs
+    t_obs_idx = np.argmin(np.abs(t_table - t_obs))
+    
+    # Extract SFR at observation time for all galaxies
+    sfr_t_obs = sfh_table[:, t_obs_idx]  # (N_galaxies,)
+    
+    # Calculate emission line luminosities
+    l_oii = sfr_to_OII3727_K98(sfr_t_obs)
+    l_halpha = sfr_to_Halpha_KTC94(sfr_t_obs)
+    
+    # Add to galaxy catalog
+    galcat['l_oii'] = l_oii
+    galcat['l_halpha'] = l_halpha
+    
+    return galcat

--- a/src/covariance_mocks/galaxy_generator.py
+++ b/src/covariance_mocks/galaxy_generator.py
@@ -9,6 +9,7 @@ Coordinates galaxy population using rgrspit_diffsky with batch processing.
 
 from jax import random as jran
 from . import CURRENT_Z_OBS, LGMP_MIN
+from .emission_lines import add_emission_lines
 
 
 def generate_galaxies(logmhost, halo_radius, halo_pos, halo_vel, Lbox, rank=0):
@@ -69,5 +70,9 @@ def generate_galaxies(logmhost, halo_radius, halo_pos, halo_vel, Lbox, rank=0):
     )
     
     print(f"Rank {rank}: generated mock with {len(galcat['pos'])} galaxies from {len(logmhost)} halos")
+    
+    # Add emission line luminosities
+    galcat = add_emission_lines(galcat)
+    print(f"Rank {rank}: added emission line luminosities (OII and H-alpha)")
     
     return galcat


### PR DESCRIPTION
# Add Emission Line Luminosity Calculations

## Summary

Implements OII and H-alpha emission line luminosity calculations in the galaxy catalog generation pipeline. The implementation extracts star formation rates from the star formation history at observation time and converts them to line luminosities using established conversion functions.

## Changes

### New Module: `src/covariance_mocks/emission_lines.py`
- Implements `add_emission_lines()` function for calculating emission line luminosities
- Uses rgrspit_diffsky emission line conversion functions (K98 for OII, KTC94 for H-alpha)
- Extracts SFR from star formation history table at time bin closest to observation time
- Adds `l_oii` and `l_halpha` properties to galaxy catalog

### Integration: `src/covariance_mocks/galaxy_generator.py`
- Integrates emission line calculations into main galaxy generation pipeline
- Calls `add_emission_lines()` after galaxy population generation
- Adds logging for emission line calculation completion

### Validation: `tests/test_catalog_validation.py`
- Adds `test_emission_line_properties_present()` test function
- Validates emission line datasets exist in generated catalogs
- Checks luminosity values are positive, finite, and non-zero
- Verifies array shapes match galaxy count
- Provides statistical summary of luminosity distributions

## Technical Details

- **SFR Extraction**: Uses `np.argmin()` to find time bin closest to observation time
- **Conversion Functions**: Leverages existing rgrspit_diffsky emission line modules
- **Data Validation**: Comprehensive checks for array shapes, value ranges, and finite values
- **Integration Point**: Emission lines calculated after galaxy properties but before return

## Testing

The implementation includes validation tests that verify:
- Emission line datasets (`galaxies/l_oii`, `galaxies/l_halpha`) exist in generated catalogs
- Luminosity arrays have correct shapes matching galaxy count
- All luminosity values are positive and finite
- At least some galaxies have non-zero emission line luminosities
- Statistical properties are reasonable (min/max/mean values)

## Files Changed

- `src/covariance_mocks/emission_lines.py` (new file, 60 lines)
- `src/covariance_mocks/galaxy_generator.py` (+5 lines)
- `tests/test_catalog_validation.py` (+41 lines)

**Total**: 3 files changed, 106 insertions

## Impact

This change adds emission line luminosity calculations to all generated galaxy catalogs without affecting existing functionality. The implementation follows the established pattern of extending galaxy properties through modular functions integrated into the main pipeline.